### PR TITLE
docs: add Wayfinder Router documentation

### DIFF
--- a/content/build/meta.json
+++ b/content/build/meta.json
@@ -9,6 +9,7 @@
     "upload",
     "access",
     "run-a-gateway",
+    "run-wayfinder-router",
     "extensions",
     "guides",
     "advanced"

--- a/content/build/run-wayfinder-router/admin-ui.mdx
+++ b/content/build/run-wayfinder-router/admin-ui.mdx
@@ -1,0 +1,137 @@
+---
+title: "Admin UI"
+description: "Web dashboard for monitoring, configuration, and content moderation"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+
+The admin UI is a built-in web dashboard that runs on a **separate port** (default 3001) from the public router (default 3000). This ensures admin endpoints are never exposed to public traffic.
+
+```
+http://localhost:3001
+```
+
+## Dashboard Pages
+
+### Status
+
+Live dashboard showing:
+- **Uptime** - How long the router has been running
+- **Operating Mode** - Current mode (proxy/route)
+- **Verification Status** - Whether verification is enabled and working
+- **Gateway Health Bar** - Visual indicator of healthy vs unhealthy gateways
+- **Cache Utilization** - Content cache size and hit rate
+- **Ping Service Stats** - Background ping status and results
+
+### Gateways
+
+Sortable table of all ar.io network gateways with:
+- **Health** - Current gateway status (healthy/unhealthy/unknown)
+- **Temperature Score** - Performance score for routing decisions
+- **Latency** - Average response time
+- **Success Rate** - Percentage of successful requests
+- **Traffic Stats** - Requests served and bytes transferred
+
+### Telemetry
+
+Time-ranged metrics with export capability:
+- **Time Ranges** - 1 hour, 6 hours, 24 hours, 7 days
+- **Request Totals** - Total requests, success rate, error breakdown
+- **Bytes Served** - Total data transferred
+- **Per-Gateway Performance** - Table with CSV export
+
+### Moderation
+
+Content moderation management:
+- **Block/Unblock** - Add or remove ArNS names and transaction IDs
+- **View Blocklist** - See all currently blocked content
+- **Enable Moderation** - If not yet configured, shows setup instructions
+
+### Settings
+
+View current configuration grouped by category:
+- Server, Mode, Routing, Verification
+- Cache, Telemetry, Rate Limiting
+- HTTP, Shutdown, Admin
+
+## Setup Wizard
+
+On first run (when `BASE_DOMAIN=localhost`), the admin UI shows a guided setup wizard that walks you through domain, routing, and verification configuration. See [Quick Start](/build/run-wayfinder-router/quick-start#setup-wizard) for details.
+
+## Security Model
+
+| | Public Port (3000) | Admin Port (3001) |
+|---|---|---|
+| **Default bind** | `0.0.0.0` (all interfaces) | `127.0.0.1` (localhost only) |
+| **Admin UI** | Not available (404) | Full access |
+| **Content serving** | Normal operation | N/A |
+
+Key security features:
+- Admin is **never** exposed on the public port
+- Default localhost binding means only local access
+- `ADMIN_PORT` must differ from `PORT` (validated at startup)
+
+<Callout type="warn">
+  If you set `ADMIN_HOST=0.0.0.0` to expose the admin UI over the network, you **must** set `ADMIN_TOKEN` to protect it.
+</Callout>
+
+## Remote Access
+
+To access the admin UI from a remote machine while keeping it secure:
+
+### Option 1: SSH Tunnel (Recommended)
+
+```bash
+# On your local machine
+ssh -L 3001:localhost:3001 your-server
+
+# Then open in your browser
+http://localhost:3001
+```
+
+This forwards port 3001 on your local machine to the server's localhost:3001, keeping the admin UI secure.
+
+### Option 2: Token Authentication
+
+If you need direct remote access:
+
+```bash
+# In .env
+ADMIN_HOST=0.0.0.0
+ADMIN_TOKEN=your-secure-random-token
+```
+
+Generate a secure token:
+
+```bash
+openssl rand -base64 32
+```
+
+The UI will prompt for the token when you load it.
+
+## Admin API Endpoints
+
+The admin UI is backed by JSON API endpoints:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/status` | GET | Aggregated status data |
+| `/api/gateways` | GET | Gateway list with health and scores |
+| `/api/telemetry` | GET | Time-ranged telemetry stats |
+| `/api/config` | GET | Current configuration (sanitized) |
+| `/api/moderation` | GET | Moderation status and blocklist |
+| `/api/config/save` | POST | Save .env file |
+| `/api/restart` | POST | Validate config and restart router |
+
+All endpoints require the `Authorization: Bearer <token>` header when `ADMIN_TOKEN` is set.
+
+## Restart from Admin UI
+
+The admin UI can restart the router after configuration changes:
+
+1. Make changes in the Settings page
+2. Click "Save Configuration"
+3. Click "Restart Router" to apply changes
+
+The restart endpoint validates the new configuration before restarting, preventing configuration errors from taking down the router.

--- a/content/build/run-wayfinder-router/configuration.mdx
+++ b/content/build/run-wayfinder-router/configuration.mdx
@@ -1,0 +1,258 @@
+---
+title: "Configuration"
+description: "Environment variables for configuring Wayfinder Router"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+All configuration is via environment variables. Create a `.env` file or set them directly in your environment.
+
+<Callout type="tip">
+  The admin UI setup wizard at `http://localhost:3001` can generate a `.env` file for you.
+</Callout>
+
+## Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | Public server port |
+| `HOST` | `0.0.0.0` | Public server bind address |
+| `BASE_DOMAIN` | `localhost` | Base domain for ArNS subdomain routing |
+| `ROOT_HOST_CONTENT` | _(empty)_ | ArNS name or txId to serve at root domain |
+| `RESTRICT_TO_ROOT_HOST` | `false` | Only serve root domain content (404 for subdomains/txIds) |
+| `GRAPHQL_PROXY_URL` | _(empty)_ | Upstream GraphQL endpoint for `/graphql` proxy |
+
+### Root Host Configuration
+
+`ROOT_HOST_CONTENT` accepts either an ArNS name or a transaction ID (auto-detected by format):
+
+```bash
+# ArNS name
+ROOT_HOST_CONTENT=wayfinder
+
+# Transaction ID (43-char base64url)
+ROOT_HOST_CONTENT=bNbA3TEQVL60xlgCcqdz4ZPHFZ711cZ3hmkpGttDt_U
+```
+
+When set, the root domain serves this content instead of the info page. The info page moves to `/wayfinder/info`.
+
+## Operating Mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEFAULT_MODE` | `proxy` | Operating mode: `proxy` or `route` |
+| `ALLOW_MODE_OVERRIDE` | `true` | Allow `?mode=` query parameter to override |
+
+**Modes:**
+- **proxy** - Fetch, verify, and serve content through the router
+- **route** - Redirect clients directly to a gateway URL
+
+## Routing
+
+Controls where content is fetched from.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ROUTING_STRATEGY` | `fastest` | Gateway selection strategy |
+| `ROUTING_GATEWAY_SOURCE` | `network` | Where to get the gateway list |
+| `ROUTING_STATIC_GATEWAYS` | _(see below)_ | Comma-separated gateway URLs (when source=`static`) |
+| `TRUSTED_PEER_GATEWAY` | `https://turbo-gateway.com` | Gateway for peer list (when source=`trusted-peers`) |
+| `TRUSTED_ARIO_GATEWAYS` | _(empty)_ | Trusted gateways (when source=`trusted-ario`) |
+
+### Routing Strategies
+
+| Strategy | Behavior | Best For |
+|----------|----------|----------|
+| `fastest` | Concurrent ping, use first responder | Lowest latency |
+| `random` | Random selection from healthy gateways | Load distribution |
+| `round-robin` | Sequential rotation through gateways | Predictable distribution |
+| `temperature` | Weighted selection based on recent performance | Production (recommended) |
+
+The `temperature` strategy tracks per-gateway latency and success rate. Better-performing gateways get more traffic, but slower gateways still receive some requests to detect improvements.
+
+### Gateway Sources
+
+| Source | Behavior |
+|--------|----------|
+| `network` | All ar.io gateways from the on-chain registry (recommended) |
+| `trusted-peers` | Peer list from `TRUSTED_PEER_GATEWAY` |
+| `trusted-ario` | Specific gateways from `TRUSTED_ARIO_GATEWAYS` |
+| `static` | Manual list from `ROUTING_STATIC_GATEWAYS` |
+
+## Verification
+
+Controls content integrity verification.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VERIFICATION_ENABLED` | `true` | Enable content hash verification |
+| `VERIFICATION_GATEWAY_SOURCE` | `top-staked` | Source for trusted gateways |
+| `VERIFICATION_GATEWAY_COUNT` | `3` | Number of gateways to query for verification |
+| `VERIFICATION_STATIC_GATEWAYS` | _(see below)_ | Comma-separated URLs (when source=`static`) |
+| `VERIFICATION_RETRY_ATTEMPTS` | `3` | Gateways to try before failing |
+| `ARNS_CONSENSUS_THRESHOLD` | `2` | Minimum gateways that must agree on ArNS resolution |
+
+### Verification Sources
+
+| Source | Behavior |
+|--------|----------|
+| `top-staked` | Top N gateways by stake (economic security, recommended) |
+| `static` | Manual list from `VERIFICATION_STATIC_GATEWAYS` |
+
+## Cache
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONTENT_CACHE_ENABLED` | `true` | Enable verified content cache |
+| `CONTENT_CACHE_MAX_SIZE_BYTES` | `53687091200` (50GB) | Maximum total cache size |
+| `CONTENT_CACHE_MAX_ITEM_SIZE_BYTES` | `2147483648` (2GB) | Maximum single item size |
+| `CONTENT_CACHE_PATH` | _(empty)_ | Disk path for persistence (empty = in-memory only) |
+| `ARNS_CACHE_TTL_MS` | `300000` (5min) | ArNS resolution cache TTL |
+
+### Disk-Backed Cache
+
+For production, enable disk persistence:
+
+```bash
+CONTENT_CACHE_PATH=./data/content-cache
+```
+
+When set:
+- LRU holds metadata only (low memory footprint)
+- Content stored as files on disk (`<sha256>.bin` + `<sha256>.meta.json`)
+- Cache survives restarts
+- Atomic writes via temp file + rename for crash safety
+
+## Admin UI
+
+The admin UI runs on a **separate port** for security.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ADMIN_UI_ENABLED` | `true` | Enable admin UI server |
+| `ADMIN_PORT` | `3001` | Admin server port (must differ from `PORT`) |
+| `ADMIN_HOST` | `127.0.0.1` | Admin bind address |
+| `ADMIN_TOKEN` | _(empty)_ | Bearer token for auth (required when not localhost) |
+| `ADMIN_OPEN_BROWSER` | `true` | Auto-open browser on startup |
+
+<Callout type="warn">
+  When `ADMIN_HOST=0.0.0.0`, you **must** set `ADMIN_TOKEN` to protect the admin UI.
+</Callout>
+
+## Resilience
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RETRY_ATTEMPTS` | `3` | Retry attempts for failed requests |
+| `RETRY_DELAY_MS` | `100` | Delay between retries |
+| `CIRCUIT_BREAKER_THRESHOLD` | `3` | Failures before marking gateway unavailable |
+| `CIRCUIT_BREAKER_RESET_MS` | `60000` (1min) | Time before retrying a broken gateway |
+| `GATEWAY_HEALTH_TTL_MS` | `300000` (5min) | Health status cache TTL |
+| `STREAM_TIMEOUT_MS` | `120000` (2min) | Per-chunk stream read timeout |
+
+## Telemetry
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TELEMETRY_ENABLED` | `true` | Enable telemetry collection |
+| `TELEMETRY_ROUTER_ID` | `router-{timestamp}` | Instance identifier |
+| `TELEMETRY_DB_PATH` | `./data/telemetry.db` | SQLite database path |
+| `TELEMETRY_RETENTION_DAYS` | `30` | Data retention period |
+| `TELEMETRY_SAMPLE_SUCCESS` | `0.1` | Sampling rate for successful requests (0.0-1.0) |
+| `TELEMETRY_SAMPLE_ERRORS` | `1.0` | Sampling rate for errors |
+
+## Rate Limiting
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RATE_LIMIT_ENABLED` | `false` | Enable per-IP rate limiting |
+| `RATE_LIMIT_WINDOW_MS` | `60000` (1min) | Rate limit window |
+| `RATE_LIMIT_MAX_REQUESTS` | `1000` | Max requests per IP per window |
+
+## Content Moderation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODERATION_ENABLED` | `false` | Enable content moderation |
+| `MODERATION_BLOCKLIST_PATH` | `./data/blocklist.json` | Blocklist file (auto-created, hot-reloaded) |
+| `MODERATION_ADMIN_TOKEN` | _(empty)_ | Bearer token for moderation API |
+
+## Arweave HTTP API Proxy
+
+Proxy Arweave node API endpoints (`/info`, `/tx/{id}`, `/block/height/{h}`, etc.).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARWEAVE_API_ENABLED` | `false` | Enable Arweave API proxy |
+| `ARWEAVE_READ_NODES` | _(Arweave tip nodes)_ | Nodes for GET requests |
+| `ARWEAVE_WRITE_NODES` | _(falls back to read)_ | Nodes for POST requests |
+| `ARWEAVE_API_CACHE_ENABLED` | `true` | Cache API responses |
+
+## Gateway Ping Service
+
+Background latency probing for the `temperature` routing strategy.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PING_ENABLED` | `true` | Enable ping service |
+| `PING_INTERVAL_HOURS` | `4` | How often to refresh ping data |
+| `PING_GATEWAY_COUNT` | `50` | Gateways to ping each round |
+| `PING_TIMEOUT_MS` | `5000` | Timeout per ping |
+| `PING_CONCURRENCY` | `10` | Maximum concurrent pings |
+
+## Shutdown
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SHUTDOWN_DRAIN_TIMEOUT_MS` | `15000` (15s) | Grace period for in-flight requests |
+| `SHUTDOWN_TIMEOUT_MS` | `30000` (30s) | Total shutdown timeout |
+
+## Logging
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOG_LEVEL` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
+
+## Example Configuration
+
+```bash
+# .env - Production example
+
+# Server
+PORT=3000
+HOST=0.0.0.0
+BASE_DOMAIN=yourdomain.com
+ROOT_HOST_CONTENT=your-arns-name
+
+# Mode
+DEFAULT_MODE=proxy
+ALLOW_MODE_OVERRIDE=false
+
+# Routing
+ROUTING_STRATEGY=temperature
+ROUTING_GATEWAY_SOURCE=network
+
+# Verification
+VERIFICATION_ENABLED=true
+VERIFICATION_GATEWAY_SOURCE=top-staked
+VERIFICATION_GATEWAY_COUNT=3
+ARNS_CONSENSUS_THRESHOLD=2
+
+# Cache
+CONTENT_CACHE_ENABLED=true
+CONTENT_CACHE_PATH=./data/content-cache
+CONTENT_CACHE_MAX_SIZE_BYTES=53687091200
+
+# Admin
+ADMIN_UI_ENABLED=true
+ADMIN_PORT=3001
+ADMIN_HOST=127.0.0.1
+
+# Telemetry
+TELEMETRY_ENABLED=true
+TELEMETRY_DB_PATH=./data/telemetry.db
+
+# Rate Limiting
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_MAX_REQUESTS=1000
+```

--- a/content/build/run-wayfinder-router/index.mdx
+++ b/content/build/run-wayfinder-router/index.mdx
@@ -10,16 +10,26 @@ import { Rocket, Settings, Monitor, Shield } from "lucide-react";
 Wayfinder Router is a lightweight proxy service that provides a **single trusted endpoint** for accessing Arweave data through the decentralized ar.io gateway network. It fetches content from multiple gateways, verifies integrity via cryptographic hash checking, and serves verified data to your users.
 
 ```
-                      ar.io Gateway Network
-                   +-----+  +-----+  +-----+
-                   | GW1 |  | GW2 |  | GW3 |
-                   +--+--+  +--+--+  +--+--+
-                      |        |        |
-Your Users --> Wayfinder Router ---------+
-                      |
-                      +-- Verification
-                      +-- Caching
-                      +-- Telemetry
+                        Your Users
+                             |
+                             v
+                    +------------------+
+                    | Wayfinder Router |
+                    |------------------|
+                    | - Verification   |
+                    | - Caching        |
+                    | - Telemetry      |
+                    +------------------+
+                             |
+              +--------------+--------------+
+              |              |              |
+              v              v              v
+          +------+       +------+       +------+
+          | GW1  |       | GW2  |       | GW3  |
+          +------+       +------+       +------+
+                 \___________+___________/
+                             |
+                 ar.io Gateway Network
 ```
 
 ## Why Use Wayfinder Router?

--- a/content/build/run-wayfinder-router/index.mdx
+++ b/content/build/run-wayfinder-router/index.mdx
@@ -1,0 +1,107 @@
+---
+title: "Wayfinder Router"
+description: "A lightweight proxy that provides verified access to Arweave data through the decentralized ar.io gateway network"
+---
+
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { Callout } from "fumadocs-ui/components/callout";
+import { Rocket, Settings, Monitor, Shield } from "lucide-react";
+
+Wayfinder Router is a lightweight proxy service that provides a **single trusted endpoint** for accessing Arweave data through the decentralized ar.io gateway network. It fetches content from multiple gateways, verifies integrity via cryptographic hash checking, and serves verified data to your users.
+
+```
+                      ar.io Gateway Network
+                   +-----+  +-----+  +-----+
+                   | GW1 |  | GW2 |  | GW3 |
+                   +--+--+  +--+--+  +--+--+
+                      |        |        |
+Your Users --> Wayfinder Router ---------+
+                      |
+                      +-- Verification
+                      +-- Caching
+                      +-- Telemetry
+```
+
+## Why Use Wayfinder Router?
+
+<Cards>
+  <Card
+    icon={<Shield />}
+    title="Content Verification"
+    description="Cryptographically verify all content against trusted gateways before serving"
+  />
+  <Card
+    icon={<Monitor />}
+    title="Single Endpoint"
+    description="Give your users one reliable URL instead of managing gateway failover in client code"
+  />
+  <Card
+    icon={<Rocket />}
+    title="Built-in Caching"
+    description="LRU cache with optional disk persistence for fast repeat access"
+  />
+  <Card
+    icon={<Settings />}
+    title="Admin Dashboard"
+    description="Web UI for configuration, monitoring, and content moderation"
+  />
+</Cards>
+
+## Two Operating Modes
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| **Proxy** | Fetch, verify, and serve content through the router | Full verification, caching, single domain |
+| **Route** | Redirect clients directly to a gateway URL | Lower latency, client-side verification |
+
+## When to Use Wayfinder Router
+
+**Use Wayfinder Router when you need:**
+- A single trusted endpoint for your application
+- Server-side content verification
+- Centralized caching and rate limiting
+- Content moderation capabilities
+- Monitoring and telemetry
+
+**Use the SDKs directly when you need:**
+- Client-side verification in browsers
+- Custom routing logic in your application
+- Integration with existing infrastructure
+
+## Architecture Overview
+
+The router separates **routing** (where to fetch data) from **verification** (who to trust):
+
+- **Routing Gateways** - Where content is fetched from (all ar.io gateways, trusted peers, or static list)
+- **Verification Gateways** - Who to trust for hash verification (top-staked gateways or static list)
+
+This means even if a routing gateway is compromised, tampered content is detected and rejected. When verification fails, the router returns an error to the client rather than serving potentially malicious content.
+
+## Get Started
+
+<Cards>
+  <Card
+    icon={<Rocket />}
+    title="Quick Start"
+    description="Get running in 30 seconds with a standalone binary or Docker"
+    href="/build/run-wayfinder-router/quick-start"
+  />
+  <Card
+    icon={<Settings />}
+    title="Configuration"
+    description="Environment variables for routing, verification, caching, and more"
+    href="/build/run-wayfinder-router/configuration"
+  />
+  <Card
+    icon={<Monitor />}
+    title="Admin UI"
+    description="Web dashboard for monitoring, configuration, and moderation"
+    href="/build/run-wayfinder-router/admin-ui"
+  />
+  <Card
+    icon={<Shield />}
+    title="Operations"
+    description="Monitoring, troubleshooting, and production deployment"
+    href="/build/run-wayfinder-router/operations"
+  />
+</Cards>

--- a/content/build/run-wayfinder-router/meta.json
+++ b/content/build/run-wayfinder-router/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Run Wayfinder Router",
+  "icon": "Router",
+  "defaultOpen": false,
+  "pages": [
+    "quick-start",
+    "configuration",
+    "admin-ui",
+    "operations"
+  ]
+}

--- a/content/build/run-wayfinder-router/operations.mdx
+++ b/content/build/run-wayfinder-router/operations.mdx
@@ -1,0 +1,275 @@
+---
+title: "Operations"
+description: "Monitoring, content moderation, and troubleshooting for Wayfinder Router"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+
+## Monitoring
+
+### Health and Readiness
+
+```bash
+# Health check (is the process running?)
+curl http://localhost:3000/wayfinder/health
+
+# Readiness check (is the router ready to serve traffic?)
+curl http://localhost:3000/wayfinder/ready
+
+# API Guard compatible health check
+curl http://localhost:3000/ar-io/healthcheck
+```
+
+Use these endpoints for load balancer health checks and orchestration systems.
+
+### Prometheus Metrics
+
+```bash
+curl http://localhost:3000/wayfinder/metrics
+```
+
+Exposes standard metrics for scraping by Prometheus. Configure your Prometheus scrape targets to point at `/wayfinder/metrics`.
+
+### Gateway Statistics
+
+```bash
+# Summary statistics
+curl http://localhost:3000/wayfinder/stats/gateways
+
+# List all tracked gateways
+curl http://localhost:3000/wayfinder/stats/gateways/list
+
+# Detailed stats for a specific gateway
+curl http://localhost:3000/wayfinder/stats/gateways/:gateway
+
+# Export telemetry data
+curl http://localhost:3000/wayfinder/stats/export
+```
+
+### Router Info
+
+```bash
+curl http://localhost:3000/wayfinder/info
+```
+
+Returns current configuration, version, uptime, and operating mode.
+
+### Telemetry Storage
+
+Telemetry is stored in SQLite at `TELEMETRY_DB_PATH` (default `./data/telemetry.db`). Configure sampling rates to control storage growth:
+
+```bash
+TELEMETRY_SAMPLE_SUCCESS=0.1   # Sample 10% of successful requests
+TELEMETRY_SAMPLE_ERRORS=1.0    # Record all errors
+TELEMETRY_RETENTION_DAYS=30    # Auto-purge old data
+```
+
+### Log Levels
+
+Set log verbosity via `LOG_LEVEL`:
+
+```bash
+LOG_LEVEL=debug   # trace, debug, info, warn, error, fatal
+```
+
+## Content Moderation
+
+Block ArNS names or transaction IDs from being served.
+
+### Setup
+
+```bash
+MODERATION_ENABLED=true
+MODERATION_ADMIN_TOKEN=<your-secure-token>
+```
+
+Generate a secure token:
+
+```bash
+openssl rand -base64 32
+```
+
+The blocklist is stored at `MODERATION_BLOCKLIST_PATH` (default `./data/blocklist.json`) and is hot-reloaded on changes.
+
+### API Endpoints
+
+All admin endpoints require `Authorization: Bearer <token>` header.
+
+<Tabs items={['Block Content', 'List/Check', 'Unblock']}>
+  <Tab value="Block Content">
+    ```bash
+    # Block an ArNS name
+    curl -X POST http://localhost:3000/wayfinder/moderation/block \
+      -H "Authorization: Bearer YOUR_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"type":"arns","value":"badcontent","reason":"Policy violation"}'
+
+    # Block a transaction ID
+    curl -X POST http://localhost:3000/wayfinder/moderation/block \
+      -H "Authorization: Bearer YOUR_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"type":"txid","value":"abc123...","reason":"DMCA takedown"}'
+    ```
+  </Tab>
+  <Tab value="List/Check">
+    ```bash
+    # List all blocked content
+    curl http://localhost:3000/wayfinder/moderation/blocklist \
+      -H "Authorization: Bearer YOUR_TOKEN"
+
+    # Check if content is blocked (no auth required)
+    curl http://localhost:3000/wayfinder/moderation/check/arns/somename
+
+    # Moderation statistics
+    curl http://localhost:3000/wayfinder/moderation/stats \
+      -H "Authorization: Bearer YOUR_TOKEN"
+    ```
+  </Tab>
+  <Tab value="Unblock">
+    ```bash
+    # Unblock content
+    curl -X DELETE http://localhost:3000/wayfinder/moderation/block/arns/badcontent \
+      -H "Authorization: Bearer YOUR_TOKEN"
+
+    # Reload blocklist from disk
+    curl -X POST http://localhost:3000/wayfinder/moderation/reload \
+      -H "Authorization: Bearer YOUR_TOKEN"
+    ```
+  </Tab>
+</Tabs>
+
+## Cache Management
+
+For production, enable disk-backed caching. See [Configuration](/build/run-wayfinder-router/configuration#cache) for all cache settings.
+
+### Clearing Caches
+
+**From source:**
+```bash
+bun run clear:telemetry   # Clear telemetry database
+bun run clear:all         # Clear all data (telemetry + cache)
+```
+
+**Binary or Docker:** Delete the data directory contents directly:
+```bash
+rm -rf ./data/content-cache/*
+rm ./data/telemetry.db
+```
+
+## Graceful Shutdown
+
+The router handles SIGTERM and SIGINT signals with a two-phase shutdown:
+
+1. **Drain phase** - Stop accepting new connections, wait for in-flight requests
+2. **Force exit** - If drain exceeds timeout, force shutdown
+
+```bash
+# Configuration
+SHUTDOWN_DRAIN_TIMEOUT_MS=15000   # 15s drain period
+SHUTDOWN_TIMEOUT_MS=30000         # 30s total timeout
+```
+
+```bash
+# Graceful stop
+kill -TERM <pid>
+
+# Docker (sends SIGTERM, waits 10s, then SIGKILL)
+docker stop wayfinder-router
+
+# Docker with custom timeout
+docker stop -t 30 wayfinder-router
+```
+
+## Troubleshooting
+
+### Port Conflicts
+
+If port 3000 or 3001 is already in use:
+
+```bash
+PORT=3080 ADMIN_PORT=3081 ./wayfinder-router-linux-x64
+```
+
+`ADMIN_PORT` must differ from `PORT` - the router validates this at startup.
+
+### Gateway Health Issues
+
+Check gateway status via the admin UI Gateways page or:
+
+```bash
+curl http://localhost:3000/wayfinder/stats/gateways
+```
+
+If all gateways show as unhealthy:
+- Verify internet connectivity
+- Check `ROUTING_GATEWAY_SOURCE` - if `static`, ensure URLs are correct
+- Check circuit breaker settings
+- Review logs: `LOG_LEVEL=debug`
+
+### ArNS Resolution Failures
+
+ArNS names require consensus across multiple verification gateways. If resolution fails:
+
+- Check `ARNS_CONSENSUS_THRESHOLD` (default: 2)
+- Verify the ArNS name exists on the network
+- Check verification gateway health
+- Ensure `VERIFICATION_ENABLED=true`
+
+### Subdomain Routing Not Working
+
+ArNS subdomains require `BASE_DOMAIN` to match your actual domain:
+
+```bash
+# For local development
+BASE_DOMAIN=localhost
+
+# For production
+BASE_DOMAIN=yourdomain.com
+```
+
+Requests to `{name}.yourdomain.com` are only recognized as ArNS subdomains if `BASE_DOMAIN=yourdomain.com`.
+
+### Content Verification Failures
+
+If content consistently fails verification:
+
+- Check `VERIFICATION_GATEWAY_COUNT` - more gateways increases reliability but adds latency
+- Verify `VERIFICATION_GATEWAY_SOURCE` is correctly configured
+- Check if the content transaction is still being seeded
+- Review logs for specific hash mismatch details
+
+### Memory Usage
+
+If memory usage is high:
+
+- Enable disk-backed cache: `CONTENT_CACHE_PATH=./data/content-cache`
+- Reduce cache size: `CONTENT_CACHE_MAX_SIZE_BYTES`
+- Reduce telemetry retention: `TELEMETRY_RETENTION_DAYS`
+- Increase sampling: `TELEMETRY_SAMPLE_SUCCESS=0.01`
+
+### Slow Response Times
+
+If responses are slow:
+
+- Check routing strategy - `temperature` adapts to gateway performance
+- Verify verification gateway health
+- Check network connectivity to gateways
+- Review `STREAM_TIMEOUT_MS` setting
+- Consider reducing `VERIFICATION_GATEWAY_COUNT` if latency is acceptable
+
+## Production Checklist
+
+Before deploying to production:
+
+- [ ] Set `BASE_DOMAIN` to your actual domain
+- [ ] Configure `ROOT_HOST_CONTENT` if serving at root
+- [ ] Enable disk cache: `CONTENT_CACHE_PATH=./data/content-cache`
+- [ ] Set appropriate cache size limits
+- [ ] Enable rate limiting: `RATE_LIMIT_ENABLED=true`
+- [ ] Secure admin UI: `ADMIN_TOKEN` or keep `ADMIN_HOST=127.0.0.1`
+- [ ] Configure telemetry sampling rates
+- [ ] Set up monitoring (health checks, Prometheus)
+- [ ] Configure reverse proxy (nginx/Caddy) with SSL
+- [ ] Set up log aggregation
+- [ ] Plan for graceful shutdown in your orchestration

--- a/content/build/run-wayfinder-router/quick-start.mdx
+++ b/content/build/run-wayfinder-router/quick-start.mdx
@@ -1,0 +1,248 @@
+---
+title: "Quick Start"
+description: "Get Wayfinder Router running in 30 seconds with a standalone binary or Docker"
+---
+
+import { Steps, Step } from "fumadocs-ui/components/steps";
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { Settings, Network, Shield } from "lucide-react";
+
+Get your Wayfinder Router running in **30 seconds**. No configuration needed - the admin UI wizard will guide you through setup.
+
+## Quickstart
+
+<Tabs items={['Binary', 'Docker', 'From Source']}>
+  <Tab value="Binary">
+    Download the latest binary for your platform from [GitHub Releases](https://github.com/ar-io/wayfinder-router/releases):
+
+    | Platform | Binary |
+    |----------|--------|
+    | Linux x64 | `wayfinder-router-linux-x64` |
+    | Linux ARM64 | `wayfinder-router-linux-arm64` |
+    | macOS Intel | `wayfinder-router-darwin-x64` |
+    | macOS Apple Silicon | `wayfinder-router-darwin-arm64` |
+    | Windows x64 | `wayfinder-router-windows-x64.exe` |
+
+    Each release includes `checksums.txt` with SHA256 hashes for verification.
+
+    <Steps>
+      <Step>
+        ### Download and make executable
+
+        ```bash
+        # Download (example for Linux x64)
+        curl -LO https://github.com/ar-io/wayfinder-router/releases/latest/download/wayfinder-router-linux-x64
+
+        # Make executable
+        chmod +x wayfinder-router-linux-x64
+
+        # Verify checksum (optional but recommended)
+        sha256sum wayfinder-router-linux-x64
+        ```
+      </Step>
+      <Step>
+        ### Run
+
+        ```bash
+        ./wayfinder-router-linux-x64
+        ```
+
+        The admin UI automatically opens at `http://localhost:3001` with a setup wizard.
+      </Step>
+      <Step>
+        ### Test
+
+        ```bash
+        # Fetch a test transaction
+        curl http://localhost:3000/4jBV3ofWh41KhuTs2pFvj-KBZWUkbrbCYlJH0vLA6LM
+
+        # Expected output: test
+        ```
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab value="Docker">
+    <Steps>
+      <Step>
+        ### Run with Docker
+
+        ```bash
+        docker run -p 3000:3000 -p 3001:3001 ghcr.io/ar-io/wayfinder-router:latest
+        ```
+
+        Or with Docker Compose (uses ports 3020/3021 by default):
+
+        ```bash
+        git clone https://github.com/ar-io/wayfinder-router
+        cd wayfinder-router
+        docker compose up -d
+        ```
+      </Step>
+      <Step>
+        ### Open Admin UI
+
+        Navigate to `http://localhost:3001` in your browser. The setup wizard will guide you through configuration.
+      </Step>
+      <Step>
+        ### Test
+
+        ```bash
+        curl http://localhost:3000/4jBV3ofWh41KhuTs2pFvj-KBZWUkbrbCYlJH0vLA6LM
+
+        # Expected output: test
+        ```
+      </Step>
+    </Steps>
+
+    **Production Docker:**
+
+    ```bash
+    docker run -p 3000:3000 -p 3001:3001 \
+      --env-file .env \
+      -v ./data:/app/data \
+      ghcr.io/ar-io/wayfinder-router:latest
+    ```
+
+    The `./data` volume persists telemetry, content cache, and blocklist data.
+  </Tab>
+
+  <Tab value="From Source">
+    Requires [Bun](https://bun.sh) >= 1.0.0.
+
+    <Steps>
+      <Step>
+        ### Clone and install
+
+        ```bash
+        git clone https://github.com/ar-io/wayfinder-router
+        cd wayfinder-router
+        bun install
+        ```
+      </Step>
+      <Step>
+        ### Configure (optional)
+
+        ```bash
+        cp .env.example .env
+        # Edit .env as needed, or skip and use the setup wizard
+        ```
+      </Step>
+      <Step>
+        ### Run
+
+        ```bash
+        # Development with hot reload
+        bun run dev
+
+        # Production
+        bun run start
+        ```
+
+        The admin UI opens at `http://localhost:3001`.
+      </Step>
+    </Steps>
+
+    **Build standalone binaries:**
+
+    ```bash
+    bun run build:binaries   # outputs to ./builds/
+    ```
+  </Tab>
+</Tabs>
+
+## Setup Wizard
+
+On first run (when `BASE_DOMAIN=localhost`), the admin UI shows a guided setup wizard:
+
+<Steps>
+  <Step>
+    ### Domain Configuration
+
+    Configure your base domain, port, and optional root host content. For local development, keep the defaults.
+  </Step>
+  <Step>
+    ### Routing Settings
+
+    Choose your operating mode and routing strategy:
+
+    | Setting | Options | Recommended |
+    |---------|---------|-------------|
+    | **Mode** | `proxy` or `route` | `proxy` for full verification |
+    | **Strategy** | `fastest`, `random`, `round-robin`, `temperature` | `temperature` for production |
+    | **Gateway Source** | `network`, `trusted-peers`, `static` | `network` for full decentralization |
+  </Step>
+  <Step>
+    ### Verification Settings
+
+    Enable content verification and configure trust settings:
+
+    | Setting | Default | Description |
+    |---------|---------|-------------|
+    | **Enabled** | `true` | Verify content hashes before serving |
+    | **Trust Source** | `top-staked` | Use top-staked gateways for verification |
+    | **Gateway Count** | `3` | Number of gateways to query |
+    | **Consensus** | `2` | Minimum gateways that must agree |
+  </Step>
+  <Step>
+    ### Save Configuration
+
+    The wizard generates a `.env` file. You can copy it to clipboard or save directly to the server.
+  </Step>
+</Steps>
+
+## Accessing Content
+
+Once running, access Arweave content through your router:
+
+```bash
+# By transaction ID
+http://localhost:3000/{txId}
+http://localhost:3000/{txId}/path/to/file
+
+# By ArNS name (subdomain)
+http://{arns-name}.localhost:3000/
+http://{arns-name}.localhost:3000/path/to/file
+```
+
+## Serving Content at Root Domain
+
+Configure `ROOT_HOST_CONTENT` to serve an ArNS name or transaction ID at your root domain:
+
+```bash
+# In .env
+ROOT_HOST_CONTENT=wayfinder
+
+# Or a transaction ID
+ROOT_HOST_CONTENT=bNbA3TEQVL60xlgCcqdz4ZPHFZ711cZ3hmkpGttDt_U
+```
+
+With this configuration:
+- `https://yourdomain.com/` serves the configured content
+- `https://yourdomain.com/docs` serves the `/docs` path within that content
+- `https://yourdomain.com/wayfinder/info` still returns router info
+
+## What's Next?
+
+<Cards>
+  <Card
+    icon={<Settings />}
+    title="Configuration"
+    description="Full reference for all environment variables"
+    href="/build/run-wayfinder-router/configuration"
+  />
+  <Card
+    icon={<Network />}
+    title="Admin UI"
+    description="Monitor gateways, view telemetry, manage moderation"
+    href="/build/run-wayfinder-router/admin-ui"
+  />
+  <Card
+    icon={<Shield />}
+    title="Operations"
+    description="Production deployment, monitoring, and troubleshooting"
+    href="/build/run-wayfinder-router/operations"
+  />
+</Cards>

--- a/content/learn/wayfinder/integration.mdx
+++ b/content/learn/wayfinder/integration.mdx
@@ -4,7 +4,7 @@ description: "Use the Wayfinder browser extension or integrate Wayfinder librari
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
-import { Compass, Code, BookOpen } from 'lucide-react';
+import { Compass, Code, BookOpen, Server } from 'lucide-react';
 
 ## Getting Started
 
@@ -46,6 +46,18 @@ Web developers will likely be interested in [wayfinder-react](/sdks/wayfinder/wa
 - **Custom hooks** - Simplified data fetching and state management
 - **Component library** - Pre-built UI components for common patterns
 - **TypeScript support** - Full type safety out of the box
+
+### Wayfinder Router
+
+For teams who want a **ready-to-deploy proxy service**, [Wayfinder Router](/build/run-wayfinder-router) provides:
+
+- **Single trusted endpoint** - Give your users one reliable URL
+- **Server-side verification** - All content verified before serving
+- **Built-in caching** - LRU cache with optional disk persistence
+- **Admin dashboard** - Web UI for monitoring and moderation
+- **Standalone binary** - No runtime dependencies, runs anywhere
+
+This is ideal when you want infrastructure-level Wayfinder without embedding the SDK in your application.
 
 ## Common Integration Pattern: Preferred with Fallback
 
@@ -177,5 +189,11 @@ function WayfinderImage({ txId }: { txId: string }) {
     description="Learn about React-specific hooks and components"
     href="/sdks/wayfinder/wayfinder-react"
     icon={<BookOpen className="w-8 h-8" />}
+  />
+  <Card
+    title="Run Wayfinder Router"
+    description="Deploy a standalone proxy service with built-in verification"
+    href="/build/run-wayfinder-router"
+    icon={<Server className="w-8 h-8" />}
   />
 </Cards>

--- a/content/sdks/wayfinder/index.mdx
+++ b/content/sdks/wayfinder/index.mdx
@@ -7,7 +7,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Card, Cards } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
-import { BookOpen, Network, Server, Globe, Terminal, Chrome } from "lucide-react";
+import { BookOpen, Network, Server, Globe, Terminal, Chrome, Router } from "lucide-react";
 
 Wayfinder leverages the decentralized ar.io Network to provide robust, censorship-resistant access to data stored on Arweave, removing reliance on centralized gateways. By routing requests through a distributed set of community-operated gateways, Wayfinder ensures high availability, redundancy, and improved performance for users and applications.
 
@@ -36,7 +36,17 @@ Choose your environment to get started with Wayfinder:
     description="React hooks and components for browser applications"
     href="/sdks/wayfinder/wayfinder-react"
   />
+  <Card
+    icon={<Server />}
+    title="Wayfinder Router"
+    description="Standalone proxy service with built-in verification and caching"
+    href="/build/run-wayfinder-router"
+  />
 </Cards>
+
+<Callout type="tip">
+  **Don't want to embed an SDK?** [Wayfinder Router](/build/run-wayfinder-router) is a standalone proxy you can deploy to provide a single verified endpoint for your users.
+</Callout>
 
 ## Quick Examples
 
@@ -104,15 +114,15 @@ function WayfinderImage({ txId }: { txId: string }) {
     href="/build/access"
   />
   <Card
+    icon={<Router />}
+    title="Run Wayfinder Router"
+    description="Deploy a standalone verified proxy for your users"
+    href="/build/run-wayfinder-router"
+  />
+  <Card
     icon={<Server />}
     title="Run a Gateway"
     description="Join the network by operating your own ar.io gateway"
     href="/build/run-a-gateway/quick-start"
-  />
-  <Card
-    icon={<Globe />}
-    title="Integrate Wayfinder into your App"
-    description="Advanced integration patterns and best practices"
-    href="/sdks/wayfinder/wayfinder-core"
   />
 </Cards>


### PR DESCRIPTION
Add comprehensive documentation for Wayfinder Router under build/run-wayfinder-router/:
- index.mdx: Overview, architecture, use cases
- quick-start.mdx: Binary, Docker, and source installation
- configuration.mdx: Complete environment variable reference
- admin-ui.mdx: Dashboard pages, security model, remote access
- operations.mdx: Monitoring, moderation, troubleshooting, production checklist

Also update cross-links:
- Add Router to sdks/wayfinder/index.mdx Getting Started cards
- Add Router section to learn/wayfinder/integration.mdx
- Add run-wayfinder-router to build/meta.json navigation