### PR TITLE
docs(turbo): free-tier allowance (getFreeStatus) + fix stale 100 KiB → 105 KiB

### DIFF
--- a/content/build/guides/migrate-from-ipfs-to-arweave.mdx
+++ b/content/build/guides/migrate-from-ipfs-to-arweave.mdx
@@ -195,7 +195,7 @@ Before starting, estimate total upload cost:
 3. Purchase sufficient [Turbo Credits](/build/upload/turbo-credits) before beginning.
 
 <Callout type="info">
-  Uploads under **100 KiB are free** and do not require a prior top-up. For large migrations this is negligible, but worth knowing for small metadata files.
+  Uploads under **105 KiB are free** and do not require a prior top-up. For large migrations this is negligible, but worth knowing for small metadata files.
 </Callout>
 
 ### Concurrency and rate limits

--- a/content/build/testnet/uploading-and-credits.mdx
+++ b/content/build/testnet/uploading-and-credits.mdx
@@ -75,6 +75,33 @@ A `200` returns `{ id, winc, dataCaches, ... }`. **`winc: "0"` means the upload 
   - Over the free allowance, or an item too big to be free, returns **`402`**
     `{ code: "FREE_TIER_EXHAUSTED", topUpUrl, byteCount }` → [top up credits](#getting-credits).
 
+### Check your remaining free allowance
+
+Before uploading, check how many free-tier bytes a wallet has left with
+`GET /v1/account/free` — **no signature required**, any wallet by address:
+
+```http
+GET https://payment.services.ar-io.dev/v1/account/free?address=<native-address>
+```
+
+```jsonc
+// bytesRemaining: null = unlimited (exempt wallet); 0 = free tier disabled
+{ "bytesRemaining": 7340032 }
+```
+
+With the [Turbo SDK](/sdks/turbo-sdk):
+
+```ts
+const { bytesRemaining } = await turbo.getFreeStatus();            // your own wallet (authenticated)
+const { bytesRemaining } = await turbo.getFreeStatus('<address>'); // any wallet (unauthenticated)
+```
+
+Or the CLI: `turbo free-status --address <native-address>`.
+
+`bytesRemaining` is a wallet-side figure and advisory — the per-subnet cap and the
+authoritative free/charge decision are applied at upload time. Deployment-wide
+free-tier limits are reported by `GET /v1/info`.
+
 ## Getting credits
 
 Credits (Turbo **"winc"**) are what the bundler debits for **paid uploads** and **ArNS

--- a/content/build/upload/index.mdx
+++ b/content/build/upload/index.mdx
@@ -31,7 +31,7 @@ There are multiple ways to upload data to Arweave. Each has its own attributes a
         </span>
       </span>
     }
-    description="Production-ready bundling service with enterprise features • Pay with credit cards, AR, ETH, SOL, MATIC • Free uploads under 100 KiB • Automatic retry & confirmation"
+    description="Production-ready bundling service with enterprise features • Pay with credit cards, AR, ETH, SOL, MATIC • Free uploads under 105 KiB • Automatic retry & confirmation"
     href="/build/upload/bundling-services"
     icon={<Image src="/ecosystem-logos/logo-turbo.svg" alt="Turbo" width={40} height={40} />}
   />
@@ -54,7 +54,7 @@ There are multiple ways to upload data to Arweave. Each has its own attributes a
 **Cost Effective**
 
 - Pay per byte, not empty chunks - only pay for actual data uploaded
-- Free uploads under 100 KiB - subsidized small file uploads
+- Free uploads under 105 KiB - subsidized small file uploads
 - No failed upload charges - automatic retry without extra costs
 
 **Developer Experience**

--- a/content/build/upload/turbo-credits.mdx
+++ b/content/build/upload/turbo-credits.mdx
@@ -91,6 +91,9 @@ const result = await turbo.topUpWithTokens({
 
 // Check balance
 const { winc } = await turbo.getBalance();
+
+// Check remaining free-tier allowance (bytes). null = unlimited, 0 = free tier off.
+const { bytesRemaining } = await turbo.getFreeStatus();
 ```
 
 See the [Turbo SDK documentation](/sdks/turbo-sdk) and [GitHub repository](https://github.com/ardriveapp/turbo-sdk) for complete examples.
@@ -103,6 +106,9 @@ turbo top-up --token base-usdc --amount 1
 
 # Check balance
 turbo balance
+
+# Check remaining free-tier upload allowance
+turbo free-status
 ```
 
 See the [Turbo Node.js CLI documentation](https://github.com/ardriveapp/turbo-sdk/?tab=readme-ov-file#cli) for installation and usage.
@@ -200,7 +206,7 @@ Credits can be shared via the Console App at [console.ar.io](https://console.ar.
 - Turbo top up fees cover the costs of managing infrastructure and, in the case of crypto-based top ups, token liquidity.
 - No additional fees are applied when credits are spent.
 - Credits maintain a 1:1 peg of storage purchasing power as Arweave's data storage rates and token price fluctuate.
-- **Uploads under 100 KiB are completely free and do not require a prior top up.**
+- **Small uploads can be free.** Items up to **105 KiB** are eligible for the free tier, subject to a per-wallet **and** per-subnet lifetime allowance — an upload must fit under both. Check a wallet's remaining free allowance with `turbo.getFreeStatus()` (below).
 
 
 | Currency          | Top Up Fee Percentage |

--- a/content/build/upload/x402-uploading-to-turbo.mdx
+++ b/content/build/upload/x402-uploading-to-turbo.mdx
@@ -60,10 +60,10 @@ await turbo.uploadRawX402Data({
 });
 ```
 
-NOTE: For free uploads under 100 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
+NOTE: For free uploads under 105 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
 
 ```ts
-// Unsigned free upload of raw data under 100 KiB
+// Unsigned free upload of raw data under 105 KiB
 const turbo = TurboFactory.unauthenticated({ token: "base-usdc" });
 await turbo.uploadRawX402Data({
   data: myRawData,

--- a/content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx
+++ b/content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx
@@ -11,6 +11,20 @@ Issues a signed request to get the credit balance of a wallet measured in AR (me
 const { winc: balance } = await turbo.getBalance();
 ```
 
+#### getFreeStatus()
+
+Returns the wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }`, so you can tell up front whether an upload will be free. `bytesRemaining` is `null` for a wallet with an unlimited allowance (an exempt/partner wallet) and `0` when the free tier is disabled on the target Turbo deployment. It is advisory — the authoritative free/charge decision is made at upload time — and is a wallet-side figure (a per-network cap may also apply).
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus();
+```
+
+It is also available on the `TurboUnauthenticatedClient` for any wallet by address:
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
+```
+
 #### signer.getNativeAddress()
 
 Returns the [native address][docs/native-address] of the connected signer.
@@ -208,10 +222,10 @@ await turbo.uploadRawX402Data({
 });
 ```
 
-NOTE: For free uploads under 100 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
+NOTE: For free uploads under 105 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
 
 ```ts
-// Unsigned free upload of raw data under 100 KiB
+// Unsigned free upload of raw data under 105 KiB
 const turbo = TurboFactory.unauthenticated({ token: 'base-usdc' });
 await turbo.uploadRawX402Data({
   data: myRawData,

--- a/content/sdks/turbo-sdk/(apis)/turbounauthenticatedclient.mdx
+++ b/content/sdks/turbo-sdk/(apis)/turbounauthenticatedclient.mdx
@@ -19,6 +19,14 @@ Returns the list of countries supported by the Turbo Payment Service's top up wo
 const countries = await turbo.getSupportedCountries();
 ```
 
+#### getFreeStatus()
+
+Returns a wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }` — `null` for an unlimited (exempt/partner) wallet, `0` when the free tier is disabled. Advisory: the authoritative free/charge decision is made at upload time.
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
+```
+
 #### getFiatToAR()
 
 Returns the current raw fiat to AR conversion rate for a specific currency as reported by third-party pricing oracles.

--- a/content/sdks/turbo-sdk/llm.txt
+++ b/content/sdks/turbo-sdk/llm.txt
@@ -8,6 +8,20 @@ Issues a signed request to get the credit balance of a wallet measured in AR (me
 const { winc: balance } = await turbo.getBalance();
 ```
 
+#### getFreeStatus()
+
+Returns the wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }`, so you can tell up front whether an upload will be free. `bytesRemaining` is `null` for a wallet with an unlimited allowance (an exempt/partner wallet) and `0` when the free tier is disabled on the target Turbo deployment. It is advisory — the authoritative free/charge decision is made at upload time — and is a wallet-side figure (a per-network cap may also apply).
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus();
+```
+
+It is also available on the `TurboUnauthenticatedClient` for any wallet by address:
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
+```
+
 #### signer.getNativeAddress()
 
 Returns the [native address][docs/native-address] of the connected signer.
@@ -205,10 +219,10 @@ await turbo.uploadRawX402Data({
 });
 ```
 
-NOTE: For free uploads under 100 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
+NOTE: For free uploads under 105 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
 
 ```ts
-// Unsigned free upload of raw data under 100 KiB
+// Unsigned free upload of raw data under 105 KiB
 const turbo = TurboFactory.unauthenticated({ token: 'base-usdc' });
 await turbo.uploadRawX402Data({
   data: myRawData,
@@ -583,6 +597,14 @@ Returns the list of countries supported by the Turbo Payment Service's top up wo
 
 ```typescript
 const countries = await turbo.getSupportedCountries();
+```
+
+#### getFreeStatus()
+
+Returns a wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }` — `null` for an unlimited (exempt/partner) wallet, `0` when the free tier is disabled. Advisory: the authoritative free/charge decision is made at upload time.
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
 #### getFiatToAR()

--- a/public/sdks/turbo-sdk/llm.txt
+++ b/public/sdks/turbo-sdk/llm.txt
@@ -8,6 +8,20 @@ Issues a signed request to get the credit balance of a wallet measured in AR (me
 const { winc: balance } = await turbo.getBalance();
 ```
 
+#### getFreeStatus()
+
+Returns the wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }`, so you can tell up front whether an upload will be free. `bytesRemaining` is `null` for a wallet with an unlimited allowance (an exempt/partner wallet) and `0` when the free tier is disabled on the target Turbo deployment. It is advisory — the authoritative free/charge decision is made at upload time — and is a wallet-side figure (a per-network cap may also apply).
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus();
+```
+
+It is also available on the `TurboUnauthenticatedClient` for any wallet by address:
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
+```
+
 #### signer.getNativeAddress()
 
 Returns the [native address][docs/native-address] of the connected signer.
@@ -205,10 +219,10 @@ await turbo.uploadRawX402Data({
 });
 ```
 
-NOTE: For free uploads under 100 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
+NOTE: For free uploads under 105 KiB, this method of upload currently does not require a signature and can be used with an unauthenticated client.
 
 ```ts
-// Unsigned free upload of raw data under 100 KiB
+// Unsigned free upload of raw data under 105 KiB
 const turbo = TurboFactory.unauthenticated({ token: 'base-usdc' });
 await turbo.uploadRawX402Data({
   data: myRawData,
@@ -583,6 +597,14 @@ Returns the list of countries supported by the Turbo Payment Service's top up wo
 
 ```typescript
 const countries = await turbo.getSupportedCountries();
+```
+
+#### getFreeStatus()
+
+Returns a wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }` — `null` for an unlimited (exempt/partner) wallet, `0` when the free tier is disabled. Advisory: the authoritative free/charge decision is made at upload time.
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
 #### getFiatToAR()


### PR DESCRIPTION
## What

Documents the new **"how much free tier is left"** capability (the Turbo SDK `getFreeStatus` method / `GET /v1/account/free`) and does a comprehensive accuracy pass on the free-tier docs — anchored on the [testnet Uploading & Credits](https://docs.ar.io/build/testnet/uploading-and-credits/#limits--responses) page.

## Changes

**New capability — "Check your remaining free allowance":**
- **testnet Uploading & Credits**: adds a subsection under _Limits & responses_ showing `GET /v1/account/free`, `turbo.getFreeStatus()` (authenticated + by-address), and `turbo free-status` (CLI).
- **Turbo Credits (production)** + **SDK API reference** (both `TurboAuthenticatedClient` and `TurboUnauthenticatedClient`): `getFreeStatus()` documented alongside `getBalance()`, plus SDK/CLI examples.

**Accuracy fixes (found in the pass):**
- The per-item free cap is **105 KiB** (107520 bytes) in both services — the docs said **100 KiB** in several places (`turbo-credits`, `upload/index`, `migrate-from-ipfs`, `x402-uploading`, SDK `llm.txt`). All corrected. (The `505 KiB` figure elsewhere is only what `/v1/info` *advertises*, not the free decision.)
- The Turbo Credits page said uploads under 100 KiB were "completely free and do not require a prior top up," which **understated the caps** — corrected to note the free tier is subject to a **per-wallet AND per-subnet lifetime allowance** (an upload must fit under both).

**Generated files:** regenerated `content/sdks/turbo-sdk/llm.txt` (+ `public/` copy) via `scripts/generate-sdk-llm-texts.js` so the SDK LLM context includes `getFreeStatus` and the 105 KiB correction.

## Dependencies

- Pairs with Turbo SDK PR [ardriveapp/turbo-sdk#437](https://github.com/ardriveapp/turbo-sdk/pull/437) (`getFreeStatus`, → `alpha`).
- The live examples require `GET /v1/account/free` to be **deployed** on the referenced Turbo services (sandbox / production). The endpoint is merged to the bundler's `develop` (PR #219); this docs change should land once it's deployed where the docs point.

Fence balance checked; frontmatter untouched — the PR preview build validates the MDX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)