### PR TITLE
docs(turbo): payment history (getPaymentHistory) SDK method + CLI

### DIFF
--- a/content/build/upload/turbo-credits.mdx
+++ b/content/build/upload/turbo-credits.mdx
@@ -94,6 +94,9 @@ const { winc } = await turbo.getBalance();
 
 // Check remaining free-tier allowance (bytes). null = unlimited, 0 = free tier off.
 const { bytesRemaining } = await turbo.getFreeStatus();
+
+// Review your own top-up history (crypto + fiat), newest first, paginated
+const { payments, hasMore, cursor } = await turbo.getPaymentHistory({ limit: 25 });
 ```
 
 See the [Turbo SDK documentation](/sdks/turbo-sdk) and [GitHub repository](https://github.com/ardriveapp/turbo-sdk) for complete examples.
@@ -109,6 +112,9 @@ turbo balance
 
 # Check remaining free-tier upload allowance
 turbo free-status
+
+# Review your own top-up (payment) history
+turbo payment-history --limit 25
 ```
 
 See the [Turbo Node.js CLI documentation](https://github.com/ardriveapp/turbo-sdk/?tab=readme-ov-file#cli) for installation and usage.

--- a/content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx
+++ b/content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx
@@ -25,6 +25,23 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
+#### getPaymentHistory({ limit, cursor })
+
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+
+Each item is discriminated by `type`. A `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`. The history covers credit and card top-ups; it is not a full ledger of spends.
+
+```typescript
+const { payments, hasMore, cursor } = await turbo.getPaymentHistory({
+  limit: 25,
+});
+
+// Fetch the next page while more results remain
+if (hasMore) {
+  const next = await turbo.getPaymentHistory({ limit: 25, cursor });
+}
+```
+
 #### signer.getNativeAddress()
 
 Returns the [native address][docs/native-address] of the connected signer.

--- a/content/sdks/turbo-sdk/llm.txt
+++ b/content/sdks/turbo-sdk/llm.txt
@@ -22,6 +22,23 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
+#### getPaymentHistory({ limit, cursor })
+
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+
+Each item is discriminated by `type`. A `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`. The history covers credit and card top-ups; it is not a full ledger of spends.
+
+```typescript
+const { payments, hasMore, cursor } = await turbo.getPaymentHistory({
+  limit: 25,
+});
+
+// Fetch the next page while more results remain
+if (hasMore) {
+  const next = await turbo.getPaymentHistory({ limit: 25, cursor });
+}
+```
+
 #### signer.getNativeAddress()
 
 Returns the [native address][docs/native-address] of the connected signer.

--- a/public/sdks/turbo-sdk/llm.txt
+++ b/public/sdks/turbo-sdk/llm.txt
@@ -22,6 +22,23 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
+#### getPaymentHistory({ limit, cursor })
+
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+
+Each item is discriminated by `type`. A `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`. The history covers credit and card top-ups; it is not a full ledger of spends.
+
+```typescript
+const { payments, hasMore, cursor } = await turbo.getPaymentHistory({
+  limit: 25,
+});
+
+// Fetch the next page while more results remain
+if (hasMore) {
+  const next = await turbo.getPaymentHistory({ limit: 25, cursor });
+}
+```
+
 #### signer.getNativeAddress()
 
 Returns the [native address][docs/native-address] of the connected signer.


### PR DESCRIPTION
## Summary

Documents the new Turbo SDK **`getPaymentHistory`** — a wallet's own top-up (payment) history (crypto + fiat), merged newest-first and keyset-paginated. Signature-required and self-scoped, so it's documented on the authenticated client only.

Pairs with turbo-sdk **PR #438** (`getPaymentHistory`). Mirrors the structure of the merged `getFreeStatus` docs (PR #126).

## Changes
- **Turbo SDK API reference** (`turboauthenticatedclient.mdx`): `getPaymentHistory({ limit, cursor })` — the `{ payments, hasMore, cursor }` shape, the crypto vs fiat item fields, pagination, and that it's the wallet's own top-ups (crypto + fiat), not a full ledger.
- **Turbo Credits** (`turbo-credits.mdx`): added `getPaymentHistory` to the SDK quick-example and a `turbo payment-history --limit 25` CLI example, alongside `getBalance`/`getFreeStatus`.
- Regenerated SDK **`llm.txt`** (content + public).

Pure additions (+57), no unrelated regen churn.

## Requires
`GET /v1/account/payments` deployed on the referenced Turbo services, and turbo-sdk PR #438 released to consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
