### PR TITLE
docs: document bundle location hints for data retrieval

### DIFF
--- a/content/build/access/fetch-data.mdx
+++ b/content/build/access/fetch-data.mdx
@@ -45,6 +45,53 @@ https://<gateway>/raw/<transaction-id>
 
 This endpoint returns the raw data bytes without resolving manifest paths, useful when you need the exact stored data.
 
+## Providing Bundle Location Hints
+
+An ANS-104 data item is stored inside a bundle whose root transaction is written
+to Arweave. A gateway normally resolves the data item ID to that root transaction
+and the item's byte range automatically. If you already know this location, you
+can include it as request headers to avoid the lookup step:
+
+| Request header | Value |
+| --- | --- |
+| `X-AR-IO-Root-Transaction-Id` | ID of the root Arweave transaction containing the data item |
+| `X-AR-IO-Data-Item-Offset` | Byte offset of the complete data item within the root bundle |
+| `X-AR-IO-Data-Item-Size` | Size of the complete data item in bytes |
+
+For example, when all three values are known:
+
+```bash
+curl --fail --location \
+  --header "X-AR-IO-Root-Transaction-Id: <root-transaction-id>" \
+  --header "X-AR-IO-Data-Item-Offset: <data-item-offset>" \
+  --header "X-AR-IO-Data-Item-Size: <data-item-size>" \
+  --output <output-file> \
+  "https://<gateway>/<data-item-id>"
+```
+
+If only the root transaction ID is known, it can be supplied on its own. The
+gateway will use it to locate the bundle and determine the data item's offset
+and size:
+
+```bash
+curl --fail --location \
+  --header "X-AR-IO-Root-Transaction-Id: <root-transaction-id>" \
+  --output <output-file> \
+  "https://<gateway>/<data-item-id>"
+```
+
+<Callout type="info">
+  Location hints are an optional retrieval optimization, not a different data
+  address. Keep requesting the data item ID in the URL. The gateway validates
+  the resolved data item against that ID and returns an error if the hints do
+  not identify the requested item.
+</Callout>
+
+You can inspect a successful `HEAD` or `GET` response for the same
+`X-AR-IO-Root-Transaction-Id`, `X-AR-IO-Data-Item-Offset`, and
+`X-AR-IO-Data-Item-Size` headers. Save those values when you need to make later
+requests without repeating root-transaction discovery.
+
 <Callout type="info">
   **Learn More:** For complete API documentation and testing, see the [ar.io
   Node Data APIs](/apis/ar-io-node/data).


### PR DESCRIPTION
### Motivation

- Gateways can serve ANS-104 bundled data items but clients may need a way to shortcut root-transaction lookup for faster or more reliable retrieval.  
- The changelog noted undocumented offset/root-tx hints; the docs should capture the request headers and examples so integrators (and support) can triage older bundle retrieval issues.  

### Description

- Add a new "Providing Bundle Location Hints" section to `content/build/access/fetch-data.mdx` that documents the optional request headers `X-AR-IO-Root-Transaction-Id`, `X-AR-IO-Data-Item-Offset`, and `X-AR-IO-Data-Item-Size`.  
- Provide `curl` examples for supplying either the full location hints (root+offset+size) or just the root transaction ID.  
- Clarify that these hints are an optional retrieval optimization, that requests must still use the data-item ID URL, and that gateways validate hints against the requested item; also note that clients can record these headers from successful `HEAD`/`GET` responses for later use.  

### Testing

- `git diff --check` — succeeded.  
- `yarn lint` (`eslint src/ content/`) — succeeded.  
- `yarn check-links` — executed and reported several pre-existing broken links unrelated to the changed page.  
- `yarn build` — attempted but blocked by the environment failing to fetch Google Fonts (network limitation), so a full production build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7cc3c6383c8325b9a1a65ed6e572ed)