### PR TITLE
docs: From Build to Permanent App — connect Turbo uploads with ArNS publishing

### DIFF
--- a/content/build/guides/hosting-decentralised-apps/deploy-permanent-dapp.mdx
+++ b/content/build/guides/hosting-decentralised-apps/deploy-permanent-dapp.mdx
@@ -1,17 +1,44 @@
 ---
-title: "Deploy a Permanent dApp"
-description: "End-to-end guide to deploying a permanent web application using a Solana wallet — upload, register a name, and go live"
+title: "From Build to Permanent App"
+description: "Deploy a static web app with Turbo, publish it with ArNS, and keep one stable URL across every release"
 ---
 
 import { Rocket, Globe, Upload, Check } from 'lucide-react';
 
-Deploy a permanent web application to Arweave with a human-readable ArNS name — using only your Solana wallet. Your app will be served by the network of decentralized gateways with zero ongoing hosting costs.
+This guide connects the last mile of shipping a web app: turn a static build into a permanent Turbo upload, then publish it at a human-readable ArNS name. You only need a Solana wallet, and the same URL can follow every release even though each upload remains immutable.
+
+## How Turbo and ArNS Fit Together
+
+```text
+Static build folder
+       │
+       ▼
+Turbo uploads files + creates a manifest
+       │
+       ▼
+Permanent manifest transaction ID
+       │
+       ▼
+ArNS record points your name to that ID
+       │
+       ▼
+https://yourname.ar.io
+```
+
+- **Turbo** stores the build files and creates an Arweave manifest that routes paths such as `/`, `/assets/app.js`, and `/about/`.
+- **ArNS** gives that immutable manifest a stable name. On the next release, update the name to the new manifest ID instead of changing the URL you share.
+- **ar.io gateways** resolve the name and serve the manifest's files. The app is also available directly by its transaction ID, independently of ArNS.
+
+<Callout type="info" title="Prefer one command?">
+  [ARIO Deploy](/build/guides/hosting-decentralised-apps/deploying-with-ario-deploy) automates the same upload, manifest, and ArNS update workflow. Continue here if you want to understand and control each SDK operation yourself.
+</Callout>
 
 ## What You'll Build
 
 By the end of this guide, your app will be:
 - **Permanently stored** on Arweave (can never be deleted or modified)
-- **Accessible** at `https://yourname.ar.io` (and every other ar.io gateway)
+- **Addressable by transaction ID** so every deployed version can still be retrieved
+- **Accessible** at `https://yourname.ar.io` (and through other ar.io gateways)
 - **Owned by you** as a Metaplex Core NFT (the ArNS name token)
 
 ## Prerequisites
@@ -201,7 +228,19 @@ Requires `@ar.io/sdk` version 3.23+ for Solana support.
     # Should return 200 OK with your app's index.html
     ```
 
-    Your app is now permanently hosted and accessible through every ar.io gateway in the network.
+    Verify both layers so it is easier to diagnose a problem:
+
+    ```bash
+    # Storage and manifest routing
+    curl -I https://turbo-gateway.com/YOUR_MANIFEST_TX_ID
+
+    # Name resolution
+    curl -I https://my-cool-app.ar.io
+    ```
+
+    If the transaction URL works but the ArNS URL does not, confirm that the root (`@`) record contains the manifest transaction ID and allow for the record's TTL. If neither URL works, check the upload result and make sure the build folder contained an `index.html` file.
+
+    Your app is now permanently hosted and accessible through the ar.io gateway network.
   </Step>
 </Steps>
 

--- a/content/build/guides/hosting-decentralised-apps/index.mdx
+++ b/content/build/guides/hosting-decentralised-apps/index.mdx
@@ -38,8 +38,8 @@ We'll cover the following:
 
 <Cards>
   <Card
-    title="Deploy a Permanent dApp"
-    description="Walk through an end-to-end deployment: upload a static app, register an ArNS name, and point the name at your app."
+    title="From Build to Permanent App"
+    description="Use Turbo and ArNS together: upload a static build, register a stable name, and publish your app."
     href="/build/guides/hosting-decentralised-apps/deploy-permanent-dapp"
     icon={<Rocket className="w-6 h-6" />}
   />


### PR DESCRIPTION
### Motivation
- Close a cross-product documentation gap by adding a concise journey that shows how a static build becomes a permanent app using Turbo uploads and ArNS name publishing. 
- Make it easy for readers to choose between the step-by-step SDK flow and the single-command automation provided by ARIO Deploy while explaining how manifests and name records interact.

### Description
- Updated `content/build/guides/hosting-decentralised-apps/deploy-permanent-dapp.mdx` to retitle the guide to "From Build to Permanent App", add a Turbo→manifest→ArNS flow diagram, a brief explanation of how the pieces fit together, a Callout pointing to ARIO Deploy, and enhanced verification/troubleshooting instructions. 
- Updated `content/build/guides/hosting-decentralised-apps/index.mdx` to surface the new journey on the hosting guides landing card and adjust the card title/description accordingly. 
- Content additions emphasize that each upload is immutable (transaction-addressable) while ArNS provides a stable, updatable name that can point to new manifests across releases. 
- Changes are limited to documentation (MDX) and do not touch runtime source code.

### Testing
- Ran `git diff --check` which returned no whitespace or diff errors. 
- Ran `npm run lint` (`eslint src/ content/`) which completed successfully. 
- Ran `npm run check-links` which reported pre-existing broken links (5 files, 7 errors) unrelated to the modified pages. 
- Ran `npm run build` which failed in this environment because Turbopack could not fetch the Google Fonts resource, causing the build to error (network/font fetch issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a74e30664ec832d9f14c9ae98d77d64)