### PR TITLE
fix(build): escape MDX expression in turbo-sdk heading breaking Arweave deploy

### DIFF
--- a/.github/workflows/deploy-to-arweave.yaml
+++ b/.github/workflows/deploy-to-arweave.yaml
@@ -1,4 +1,4 @@
-name: Deploy to Arweave
+name: Deploy to Arweave (Production)
 
 on:
   # Trigger on push to main branch

--- a/content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx
+++ b/content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx
@@ -25,9 +25,9 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
-#### getPaymentHistory({ limit, cursor })
+#### getPaymentHistory()
 
-Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). It accepts `{ limit, cursor }`, where `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
 
 Each item is discriminated by `type`. A `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`. The history covers credit and card top-ups; it is not a full ledger of spends.
 

--- a/content/sdks/turbo-sdk/llm.txt
+++ b/content/sdks/turbo-sdk/llm.txt
@@ -22,9 +22,9 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
-#### getPaymentHistory({ limit, cursor })
+#### getPaymentHistory()
 
-Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). It accepts `{ limit, cursor }`, where `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
 
 Each item is discriminated by `type`. A `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`. The history covers credit and card top-ups; it is not a full ledger of spends.
 

--- a/public/sdks/turbo-sdk/llm.txt
+++ b/public/sdks/turbo-sdk/llm.txt
@@ -22,9 +22,9 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
-#### getPaymentHistory({ limit, cursor })
+#### getPaymentHistory()
 
-Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. It is **self-scoped**: the service reads the wallet from the signature and returns only that wallet's rows, so it is available on the `TurboAuthenticatedClient` only (there is no by-address form). It accepts `{ limit, cursor }`, where `limit` is the page size (1–100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
 
 Each item is discriminated by `type`. A `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`. The history covers credit and card top-ups; it is not a full ledger of spends.
 


### PR DESCRIPTION
## Problem

The `Deploy to Arweave` workflow has been failing on `main` at the build step:

```
Collecting page data using 3 workers ...
ReferenceError: limit is not defined
    at module evaluation (.next/server/chunks/[root-of-the-server]__1a9b2cea._.js:31:853924)
    ...
    at Object.<anonymous> (.next/server/app/api/search/route.js:5:3)

> Build error occurred
Error: Failed to collect page data for /api/search
```

## Root cause

`content/sdks/turbo-sdk/(apis)/turboauthenticatedclient.mdx:28` had:

```mdx
#### getPaymentHistory({ limit, cursor })
```

MDX treats `{ ... }` in prose as a JavaScript expression, so the heading compiled to:

```js
_jsxs(_components.h4, {
  id: "getpaymenthistory-limit-cursor-",
  children: ["getPaymentHistory(", (limit, cursor), ")"]
})
```

`limit` and `cursor` are free identifiers — nothing defines them.

The reason this took down the *whole* build rather than just one page is the import chain. Fumadocs hoists heading content into a top-level `export const toc`, so the bad reference evaluates at **module load**, not at render. And `.source/index.ts` eagerly imports all 317 MDX files, which is pulled in by `src/lib/source.ts` → `src/app/api/search/route.ts`. So the failure surfaces as `Failed to collect page data for /api/search`, which is a misleading place to start looking.

Introduced in 9e65d35d (`docs(turbo): payment history (getPaymentHistory) SDK method + CLI`) — that section was hand-written. `scripts/generate-sdk-docs.ts` already escapes braces and strips params from headings, so generated content was never affected.

## Fix

Heading becomes `#### getPaymentHistory()`, matching every other heading in the file (`getBalance()`, `getFreeStatus()`, `getWincForFiat()`, …) and matching what `generate-sdk-docs` would emit if this file were regenerated — so it won't regress on the next regeneration.

The signature info isn't lost: the body now reads "It accepts `{ limit, cursor }`, where `limit` is the page size (1–100, default 50)" (safe — it's inside backticks), and the code samples already show both params.

The generated `content/sdks/turbo-sdk/llm.txt` and `public/sdks/turbo-sdk/llm.txt` copies are hand-synced with the same edit rather than regenerated, because running `generate-sdk-llm-texts` on Windows corrupts all five SDK files (CRLF breaks its frontmatter parser — every title becomes "Untitled" and raw frontmatter leaks into the body). Worth a separate issue.

Also renames the workflow's display title to **Deploy to Arweave (Production)**, as requested.

## Verification

- Reproduced the failure locally on `main` — identical `ReferenceError: limit is not defined` for `/api/search`.
- Full `NODE_ENV=production next build` on this branch: **✓ 322/322 static pages generated, ✓ exported**, `/api/search` present in the route table.
- `eslint` clean on the changed MDX.
- Swept all of `content/` for other unescaped brace expressions in prose: everything else is imports, JSX attributes, MDX comments, or `{" "}` literals. This was the only one.

## Note (not addressed here)

The build logs a non-fatal `Failed to generate typescript schema: TypeError: a.forEach is not a function` from `fumadocs-openapi` during static generation. Build still exits 0. Unrelated to this fix; flagging it for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
