### PR TITLE
docs(arfs): name the snapshot body field jsonMetadata, not dataJson

### DIFF
--- a/content/build/advanced/arfs/entity-types.mdx
+++ b/content/build/advanced/arfs/entity-types.mdx
@@ -183,9 +183,13 @@ Unix-Time: "<seconds since unix epoch>"
 
 A JSON data object must also be uploaded with every ArFS Snapshot entity. This data contains all ArFS Drive, Folder, and File metadata changes within the associated drive, as well as any previous Snapshots. The Snapshot Data contains an array `txSnapshots`. Each item includes both the GQL and ArFS metadata details of each transaction made for the associated drive, within the snapshot's start and end period.
 
-A `tsSnapshot` contains a `gqlNode` object which uses the same GQL tags interface returned by the Arweave Gateway. It includes all of the important `block`, `owner`, `tags`, and `bundledIn` information needed by ArFS clients. It also contains a `dataJson` object which stores the correlated Data JSON for that ArFS entity.
+Each `txSnapshot` has exactly two fields, `gqlNode` and `jsonMetadata`, as siblings.
 
-For private drives, the `dataJson` object contains the JSON-string-escaped encrypted text of the associated file or folder. This encrypted text uses the file's existing `Cipher` and `Cipher-IV`. This ensures clients can decrypt this information quickly using the existing ArFS privacy protocols.
+`gqlNode` uses the same GQL tags interface returned by the Arweave Gateway. It includes all of the important `block`, `owner`, `tags`, and `bundledIn` information needed by ArFS clients.
+
+`jsonMetadata` is a **string**, not an object: the correlated Data JSON for that ArFS entity, serialized and escaped. It is `null` for an entry recorded for its GQL node alone, with no metadata body — a client must handle that rather than assume a string is always present.
+
+For private drives, `jsonMetadata` contains the JSON-string-escaped encrypted text of the associated file or folder. This encrypted text uses the file's existing `Cipher` and `Cipher-IV`. This ensures clients can decrypt this information quickly using the existing ArFS privacy protocols.
 
 ```json
 {
@@ -242,7 +246,7 @@ For private drives, the `dataJson` object contains the JSON-string-escaped encry
           }
         ]
       },
-      "dataJson": "{\"name\":\"november\",\"rootFolderId\":\"71dfc1cb-5368-4323-972a-e9dd0b1c63a0\", \"isHidden\":false}"
+      "jsonMetadata": "{\"name\":\"november\",\"rootFolderId\":\"71dfc1cb-5368-4323-972a-e9dd0b1c63a0\", \"isHidden\":false}"
     }
   ]
 }


### PR DESCRIPTION
The **Snapshot Entity Data** section documents the per-entry metadata field as `dataJson`. Both implementations write and read **`jsonMetadata`**.

- **ardrive-web** — `TxSnapshot` in `lib/utils/snapshots/snapshot_types.dart`, serialised by `tx_snapshot_to_snapshot_data.dart`, and read back in `snapshot_item.dart` as `item['jsonMetadata']`
- **ardrive-core-js** — `TxSnapshot` in `src/snapshots/snapshot_types.ts`

A client written from this page emits a key neither reader looks for, so **every entity in its snapshots reads as having no metadata** — and silently, because a missing metadata body is a legitimate state for an entry captured for its GQL node alone. Nothing errors; the data is just never there.

`dataJson` also already means something else in this ecosystem: an entity's own Data JSON custom-metadata fields, in ardrive-core-js `src/arfs/arfs_builders/arfs_builders.ts`. So the page is not only wrong, it overloads a term with an established and different meaning.

Three further corrections to the same passage:

- `tsSnapshot` was a typo for `txSnapshot`.
- The prose said the `gqlNode` object "also contains" the metadata field. It does not — the two are **siblings**, as the JSON example on this page already showed. Prose and example contradicted each other.
- The field is a **string**, and may be `null` for an entry captured for its GQL node alone. It was described as an object.

This is independent of any current feature work — it is a live documentation bug against every snapshot already on chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFV6xYmFz2meXf5EW2M1FB
